### PR TITLE
Add service account scopes

### DIFF
--- a/gcp/compute_engine/compute.tf
+++ b/gcp/compute_engine/compute.tf
@@ -16,6 +16,11 @@ resource "google_compute_instance" "default" {
     subnetwork = data.google_compute_subnetwork.default.id
   }
 
+  service_account {
+    email  = var.service_account_email
+    scopes = var.service_account_scopes
+  }
+
   scheduling {
     preemptible                 = var.is_preemptible
     automatic_restart           = var.is_preemptible ? false : true

--- a/gcp/compute_engine/variables.tf
+++ b/gcp/compute_engine/variables.tf
@@ -43,3 +43,12 @@ variable "boot_disk_type" {
   type    = string
   default = "pd-standard"
 }
+
+variable "service_account_email" {
+  type = string
+}
+
+variable "service_account_scopes" {
+  type    = list(string)
+  default = ["cloud-platform"]
+}


### PR DESCRIPTION
Added service_account block to the compute.tf, this adds the service account with default scope.